### PR TITLE
[CBP-45084] switch to build/action@v8 (action variant)

### DIFF
--- a/.cloudbees/testing/action.yml
+++ b/.cloudbees/testing/action.yml
@@ -85,7 +85,7 @@ runs:
   steps:
     - name: Configure AWS Credentials For CloudBees Automations
       id: auth
-      uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/configure-aws-credentials:${{ action.scm.sha }}
+      uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/configure-aws-credentials:${{ file.scm.sha }}
       env:
         INPUT_AUDIENCE: ${{ inputs.audience }}
         INPUT_CLOUDBEES_API_TOKEN: ${{ inputs.cloudbees-api-token }}

--- a/.cloudbees/workflows/workflow.yml
+++ b/.cloudbees/workflows/workflow.yml
@@ -3,16 +3,22 @@ kind: workflow
 name: SelfTest
 
 on:
-  workflow_dispatch: 
+  workflow_dispatch:
   push:
     branches:
       - "**"
+
+permissions:
+  scm-token-own: read
+  scm-token-org: read
+  id-token: write
 
 jobs:
   build:
     if: cloudbees.api.url == 'https://api.saas-preprod.beescloud.com' || cloudbees.api.url == 'https://api.cloudbees.io'
     permissions:
       scm-token-own: read
+      scm-token-org: read
       id-token: write
     steps:
       - name: Checkout
@@ -25,7 +31,7 @@ jobs:
 
       - id: build-image
         name: Build, scan and push to ECR
-        uses: calculi-corp/cb-internal-shared-actions/build@v8
+        uses: calculi-corp/cb-internal-shared-actions/build/action@v8
         with:
           go-binary-build: "true"
           go-binary-name: configure-aws-credentials


### PR DESCRIPTION
Switch this repo from `calculi-corp/cb-internal-shared-actions/build@v8`
(services variant) to `build/action@v8` (action variant) — the variant
intended for cloudbees-io action repos.

Follows the pattern Kirk established in
[cloudbees-io/configure-oci-credentials#33](https://github.com/cloudbees-io/configure-oci-credentials/pull/33).
The producer side (clean `image:${gitsha}` tag prepended to the destination
list) shipped in
[calculi-corp/cb-internal-shared-actions#123](https://github.com/calculi-corp/cb-internal-shared-actions/pull/123).

### Edits applied

- `.cloudbees/workflows/workflow.yml`: `build@v8` → `build/action@v8`
- `.cloudbees/workflows/workflow.yml`: add top-level + build-job `scm-token-org: read` permission (required by `build/action@v8`)
- `.cloudbees/testing/action.yml`: `${{ action.scm.sha }}` → `${{ file.scm.sha }}` so the testing action references its own file SHA. Producer PR #123 emits `image:${gitsha}` as the first destination tag, so this resolves cleanly.

Tracking: CBP-45084