### PR TITLE
[CBP-47341] Add scm org token

### DIFF
--- a/.cloudbees/workflows/workflow.yml
+++ b/.cloudbees/workflows/workflow.yml
@@ -13,6 +13,7 @@ jobs:
     if: cloudbees.api.url == 'https://api.saas-preprod.beescloud.com' || cloudbees.api.url == 'https://api.cloudbees.io'
     permissions:
       scm-token-own: read
+      scm-token-org: read
       id-token: write
     steps:
       - name: Checkout


### PR DESCRIPTION
This is needed by the common build action to clone some util repository.